### PR TITLE
File system backing store

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Where you get your cache
 - Fully synchronous or mixed sync/async caches
 - Concurrency-friendly API
 - Multi-level support with write policies per level
-- Backing stores for `Dictionary`, `NSCache`
+- Backing stores for `Dictionary`, `NSCache`, and the local disk
 
 > [!WARNING]
 > still working out some implementation details
@@ -48,6 +48,7 @@ var cache = SynchronousCache<String, String>(
     levels: [
         .writeThrough(DictionaryBackingStore()),
         .writeThrough(CacheBackingStore()),
+        .writeThrough(FileSystemBackingStore(url: localURL))
     ]
 )
 ```

--- a/Sources/ATM/FileSystemBackingStore.swift
+++ b/Sources/ATM/FileSystemBackingStore.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/Sources/ATM/FileSystemBackingStore.swift
+++ b/Sources/ATM/FileSystemBackingStore.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 /// A simple store backed by ``FileManager``.
-public struct FileSystemBackingStore<Key: NSString, Value: Codable>: BackingStore {
+public struct FileSystemBackingStore<Value: Codable>: BackingStore {
+
+	public typealias Key = String
 
 	private let directoryName: String
 	private let encoder: JSONEncoder

--- a/Sources/ATM/FileSystemBackingStore.swift
+++ b/Sources/ATM/FileSystemBackingStore.swift
@@ -1,1 +1,78 @@
 import Foundation
+
+/// A simple store backed by ``FileManager``.
+public struct FileSystemBackingStore<Key: NSString, Value: Codable>: BackingStore {
+
+	private let directoryName: String
+	private let encoder: JSONEncoder
+	private let decoder: JSONDecoder
+
+	public init(
+		directoryName: String,
+		encoder: JSONEncoder = .init(),
+		decoder: JSONDecoder = .init()
+	) {
+		self.directoryName = directoryName
+		self.encoder = encoder
+		self.decoder = decoder
+	}
+
+	public func read(_ key: Key) -> Value? {
+		do {
+			let fileURL = try FileManager.directoryAt(directoryName).appendingPathComponent(key as String)
+
+			guard FileManager.default.fileExists(at: fileURL) else {
+				return nil
+			}
+
+			let data = try Data(contentsOf: fileURL)
+			return try decoder.decode(Value.self, from: data)
+		} catch {
+			// how do we handle errors?
+			return nil
+		}
+	}
+
+	public func write(_ key: Key, _ value: Value?) {
+		do {
+			let fileURL = try FileManager.directoryAt(directoryName).appendingPathComponent(key as String)
+
+			guard let value else {
+				if FileManager.default.fileExists(at: fileURL) {
+					try FileManager.default.removeItem(at: fileURL)
+				}
+				return
+			}
+
+			let data = try encoder.encode(value)
+			try data.write(to: fileURL)
+		} catch {
+			// how do we handle errors?
+		}
+	}
+}
+
+
+private extension FileManager {
+	func fileExists(at url: URL) -> Bool {
+		fileExists(atPath: url.path)
+	}
+
+	static func directoryAt(_ path: String) throws -> URL {
+		let appSupportDirectory = try FileManager.default.url(
+			for: .applicationSupportDirectory,
+			in: .userDomainMask,
+			appropriateFor: nil,
+			create: true
+		)
+
+		let directoryPath = appSupportDirectory.appendingPathComponent(path, isDirectory: true)
+
+		var isDirectory = ObjCBool(true)
+		if !FileManager.default.fileExists(atPath: directoryPath.path, isDirectory: &isDirectory) {
+			try FileManager.default.createDirectory(at: directoryPath, withIntermediateDirectories: true)
+		}
+
+		return directoryPath
+	}
+}

--- a/Sources/ATM/FileSystemBackingStore.swift
+++ b/Sources/ATM/FileSystemBackingStore.swift
@@ -2,79 +2,81 @@ import Foundation
 
 /// A simple store backed by ``FileManager``.
 public struct FileSystemBackingStore<Value: Codable>: BackingStore {
-
 	public typealias Key = String
+	public typealias Encoder = (Value) throws -> Data
+	public typealias Decoder = (Data) throws -> Value
 
-	private let directoryName: String
-	private let encoder: JSONEncoder
-	private let decoder: JSONDecoder
+	private let url: URL
+	private let encoder: Encoder
+	private let decoder: Decoder
+	public var errorHandler: (any Error) -> Void = { _ in }
 
 	public init(
-		directoryName: String,
-		encoder: JSONEncoder = .init(),
-		decoder: JSONDecoder = .init()
-	) {
-		self.directoryName = directoryName
+		url: URL,
+		encoder: @escaping Encoder,
+		decoder: @escaping Decoder
+	) throws {
+		self.url = url
 		self.encoder = encoder
 		self.decoder = decoder
+
+		try createDirectoryIfNeeded()
+	}
+
+	public func url(for key: Key) -> URL {
+		url.appendingPathComponent(key, isDirectory: false)
+	}
+
+	private func createDirectoryIfNeeded() throws {
+		if FileManager.default.fileExists(atPath: url.path) == false {
+			try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+		}
 	}
 
 	public func read(_ key: Key) -> Value? {
 		do {
-			let fileURL = try FileManager.directoryAt(directoryName).appendingPathComponent(key as String)
+			let keyURL = url(for: key)
+			let data = try Data(contentsOf: keyURL)
 
-			guard FileManager.default.fileExists(at: fileURL) else {
-				return nil
-			}
-
-			let data = try Data(contentsOf: fileURL)
-			return try decoder.decode(Value.self, from: data)
+			return try decoder(data)
 		} catch {
-			// how do we handle errors?
+			errorHandler(error)
+
 			return nil
 		}
 	}
 
 	public func write(_ key: Key, _ value: Value?) {
 		do {
-			let fileURL = try FileManager.directoryAt(directoryName).appendingPathComponent(key as String)
+			let keyURL = url(for: key)
 
 			guard let value else {
-				if FileManager.default.fileExists(at: fileURL) {
-					try FileManager.default.removeItem(at: fileURL)
+				if FileManager.default.fileExists(atPath: keyURL.path) {
+					try FileManager.default.removeItem(at: keyURL)
 				}
+
 				return
 			}
 
-			let data = try encoder.encode(value)
-			try data.write(to: fileURL)
+			let data = try encoder(value)
+			try data.write(to: keyURL)
 		} catch {
-			// how do we handle errors?
+			errorHandler(error)
 		}
 	}
 }
 
+extension FileSystemBackingStore {
+	public init(
+		url: URL
+	) throws {
+		let jsonEncoder = JSONEncoder()
+		let jsonDecoder = JSONDecoder()
 
-private extension FileManager {
-	func fileExists(at url: URL) -> Bool {
-		fileExists(atPath: url.path)
-	}
-
-	static func directoryAt(_ path: String) throws -> URL {
-		let appSupportDirectory = try FileManager.default.url(
-			for: .applicationSupportDirectory,
-			in: .userDomainMask,
-			appropriateFor: nil,
-			create: true
+		try self.init(
+			url: url,
+			encoder: { try jsonEncoder.encode($0) },
+			decoder: { try jsonDecoder.decode(Value.self, from: $0) }
 		)
-
-		let directoryPath = appSupportDirectory.appendingPathComponent(path, isDirectory: true)
-
-		var isDirectory = ObjCBool(true)
-		if !FileManager.default.fileExists(atPath: directoryPath.path, isDirectory: &isDirectory) {
-			try FileManager.default.createDirectory(at: directoryPath, withIntermediateDirectories: true)
-		}
-
-		return directoryPath
 	}
 }

--- a/Tests/ATMTests/ATMTests.swift
+++ b/Tests/ATMTests/ATMTests.swift
@@ -36,15 +36,6 @@ struct ATMTests {
 		cache["korben"] = nil
 		#expect(cache["korben"] == nil)
 	}
-
-	@Test func fileSystemStore() throws {
-		var cache = SynchronousCache<String, Int>(
-			writePolicy: .writeThrough,
-			store: FileSystemBackingStore(directoryName: "ATM-Tests")
-		)
-
-		// implement tests here
-	}
 }
 
 extension ATMTests {

--- a/Tests/ATMTests/ATMTests.swift
+++ b/Tests/ATMTests/ATMTests.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 import Testing
 
 import ATM
@@ -33,6 +35,15 @@ struct ATMTests {
 		
 		cache["korben"] = nil
 		#expect(cache["korben"] == nil)
+	}
+
+	@Test func fileSystemStore() throws {
+		var cache = SynchronousCache<NSString, Int>(
+			writePolicy: .writeThrough,
+			store: FileSystemBackingStore(directoryName: "ATM-Tests")
+		)
+
+		// implement tests here
 	}
 }
 

--- a/Tests/ATMTests/ATMTests.swift
+++ b/Tests/ATMTests/ATMTests.swift
@@ -38,7 +38,7 @@ struct ATMTests {
 	}
 
 	@Test func fileSystemStore() throws {
-		var cache = SynchronousCache<NSString, Int>(
+		var cache = SynchronousCache<String, Int>(
 			writePolicy: .writeThrough,
 			store: FileSystemBackingStore(directoryName: "ATM-Tests")
 		)

--- a/Tests/ATMTests/FileSystemBackingStoreTests.swift
+++ b/Tests/ATMTests/FileSystemBackingStoreTests.swift
@@ -20,7 +20,7 @@ struct FileSystemBackingStoreTests {
 
 		store.write("Korben", "Dallas")
 		#expect(store.read("Korben") == "Dallas")
-		#expect(FileManager.default.fileExists(atPath: url.appendingPathComponent("Korben").path()))
+		#expect(FileManager.default.fileExists(atPath: url.appendingPathComponent("Korben").path))
 	}
 
 	@Test func errorReporting() async throws {

--- a/Tests/ATMTests/FileSystemBackingStoreTests.swift
+++ b/Tests/ATMTests/FileSystemBackingStoreTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+
+import ATM
+
+@Suite
+struct FileSystemBackingStoreTests {
+	let url: URL
+
+	init() throws {
+		self.url = FileManager.default.temporaryDirectory.appendingPathComponent("atm-cache", isDirectory: true)
+
+		try? FileManager.default.removeItem(at: url)
+	}
+
+	@Test func readAndWrite() throws {
+		let store = try FileSystemBackingStore<String>(url: url)
+
+		#expect(store.read("Korben") == nil)
+
+		store.write("Korben", "Dallas")
+		#expect(store.read("Korben") == "Dallas")
+		#expect(FileManager.default.fileExists(atPath: url.appendingPathComponent("Korben").path()))
+	}
+
+	@Test func errorReporting() async throws {
+		var store = try FileSystemBackingStore<String>(
+			url: url,
+			encoder: { _ in throw CancellationError() },
+			decoder: { _ in throw CancellationError() }
+		)
+
+		await confirmation { confirmation in
+			store.errorHandler = {
+				#expect($0 is CancellationError)
+				confirmation.confirm()
+			}
+
+			store.write("Korben", "Dallas")
+		}
+	}
+}


### PR DESCRIPTION
# motivation
hey there! 👋🏼
this PR adds the veeeery simple implementation of FileSystemBackingStore. at it's current state, it is still a **work in progress**, but i wanted to open the PR to start the discussions around the implementation (even if it's simple) and talk about some other stuff that i faced so far.

# implementation
this PR adds support for just saving values, reading them, and removing them.
- use `String` as a key for the backing store, which will act as the file name in the file system.
- values must be `Codable`.
- values will be saved in the `applicationSupportDirectory`.

  > side note: AFAIK, contents of `applicationSupportDirectory` are backed up by iCloud, and i am not sure if this is behavior this library wants to support. if not, we can exclude them.

# limitations
- testing. in my experience, it has always been tricky to write tests for FileManager. there are multiple ways this can be done, but i personally haven't tried any...
  - subclass of `FileManager`
  - an interface that derives the implementation, and create a mock object and an object that actually uses `FileManager`.
- some Swift APIs were not available to use because of the `macOS` version target. mainly the [path](https://developer.apple.com/documentation/foundation/url/path) api and some newer APIs that resolve the `applicationSupportDirectory`. the path API is "going" to be deprecated, and i don't see it being unusable for some time now, so i think it's fine :)
- error handling. a lot of the methods of `FileManager` can throw errors. the interface of `BackingStore` doesn't support throwing errors. i thought of creating a `ThrowingBackingStore`, but then it looked like it can get complicated if we want a backing store that is throwing and async. so i have left the error handling empty for now, but i am also more than happy to address it with this PR if we reach a solution!

please let me know if there is anything you think that can be done differently or in a better way!